### PR TITLE
Now trimming the $GOPATH path from source path in logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build:
 build-all: clean
 	@gox -verbose \
 		-ldflags "-X main.version=${VERSION}" \
+		-gcflags=-trimpath=${GOPATH} \
 		-os="linux darwin windows freebsd openbsd solaris" \
 		-arch="386 amd64 arm" \
 		-osarch="!darwin/arm !darwin/386" \


### PR DESCRIPTION
Partially fixes #33. 

I will leave open until we figure out how to trim every local path. Still some absolute paths left but better than before anyways.