### PR TITLE
#38: Updated Terraform dependencies to be compatible with 0.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terraform provider for cloud.ca
 
-Tested with Terraform version : 0.8.4
+Tested with Terraform version : 0.9.2
 
 # Installation
 
@@ -26,6 +26,7 @@ provider "cloudca" {
 - [**Resources documentation**](https://github.com/cloud-ca/terraform-cloudca/blob/master/cloudca/README.md)
 
 # Build from source
+Install [Go](https://golang.org/doc/install) (version 1.8 is required)
 
 Download the provider source:
 ```Shell

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: 6e30cad991529ae7e6ba3852be324abddba1c18f81c1270c7d6611c299ecd84e
-updated: 2017-02-17T15:35:21.402392321-05:00
+hash: c1e23309827856edf84476016eb3d9920c71bbfee798029252d930bb77c4f6a2
+updated: 2017-04-06T15:19:19.916798325-04:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: a3ebdb999b831ecb6ab8a226e31b07b2b9061c47
   subpackages:
   - cidr
 - name: github.com/aws/aws-sdk-go
-  version: e43e7ed87a3584fd820402855e7ff990fb10239f
+  version: 4c307b6c988d40b9601a86768b29c28e8fb033eb
   subpackages:
   - aws
   - aws/awserr
@@ -30,7 +30,6 @@ imports:
   - private/protocol/rest
   - private/protocol/restxml
   - private/protocol/xml/xmlutil
-  - private/waiter
   - service/s3
   - service/sts
 - name: github.com/bgentry/go-netrc
@@ -45,11 +44,11 @@ imports:
   - services
   - services/cloudca
 - name: github.com/go-ini/ini
-  version: ee900ca565931451fe4e4409bcbd4316331cec1c
+  version: e7fea39b01aea8d5671f6858f0532f56e8bff3a5
 - name: github.com/hashicorp/errwrap
   version: 7554cd9344cec97297fa6649b055a8c98c2a1e55
 - name: github.com/hashicorp/go-getter
-  version: c3d66e76678dce180a7b452653472f949aedfbcd
+  version: e48f67b534e614bf7fbd978fd0020f61a17b7527
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-multierror
@@ -78,7 +77,7 @@ imports:
   - parser
   - scanner
 - name: github.com/hashicorp/terraform
-  version: c1df88ac4633b61b83802bbb10c343c20d3035b5
+  version: 6365269541c8e3150ebe638a5c555e1424071417
   subpackages:
   - config
   - config/module
@@ -101,10 +100,12 @@ imports:
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/mitchellh/gox
   version: 54b619477e8932bbb6314644c867e7e6db7a9c71
+- name: github.com/mitchellh/hashstructure
+  version: ab25296c0f51f1022f01cd99dfb45f1775de8799
 - name: github.com/mitchellh/mapstructure
-  version: db1efb556f84b25a0a13a04aad883943538ad2e0
+  version: 53818660ed4955e899c0bcafa97299a388bd7c8e
 - name: github.com/mitchellh/reflectwalk
   version: 417edcfd99a4d472c262e58f22b4bfe97580f03e
 - name: github.com/satori/go.uuid
-  version: b061729afc07e77a8aa4fad0a2fd840958f1942a
+  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,7 +7,7 @@ import:
   - configuration
   - services/cloudca
 - package: github.com/hashicorp/terraform
-  version: ~0.8.4
+  version: ~0.9.2
   subpackages:
   - helper/schema
   - plugin


### PR DESCRIPTION
The provider is now compatible with Terraform 0.9.2.

Now requires Go 1.8 to build.