### PR TITLE
Fixed a bug which results in errors reading PF Rules, LB Rules and Network ACLs

### DIFF
--- a/cloudca/resource_cloudca.go
+++ b/cloudca/resource_cloudca.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strconv"
 
 	"github.com/cloud-ca/go-cloudca"
 	"github.com/cloud-ca/go-cloudca/api"
@@ -42,14 +41,6 @@ func setValueOrID(d *schema.ResourceData, key string, value string, id string) e
 func isID(id string) bool {
 	re := regexp.MustCompile(`^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$`)
 	return re.MatchString(id)
-}
-
-func readIntFromString(valStr string) int {
-	var valInt int
-	if valStr != "" {
-		valInt, _ = strconv.Atoi(valStr)
-	}
-	return valInt
 }
 
 // Provides a common, simple way to deal with 404s.

--- a/cloudca/resource_cloudca_load_balancer_rule.go
+++ b/cloudca/resource_cloudca_load_balancer_rule.go
@@ -3,7 +3,6 @@ package cloudca
 import (
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/cloud-ca/go-cloudca"
 	"github.com/cloud-ca/go-cloudca/services/cloudca"
@@ -37,11 +36,12 @@ func resourceCloudcaLoadBalancerRule() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The public IP to which the rule should be applied",
+				Description: "ID of the public IP to which the rule should be applied",
 			},
 			"public_ip": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The public IP to which the rule should be applied",
 			},
 			"network_id": {
 				Type:        schema.TypeString,
@@ -61,13 +61,13 @@ func resourceCloudcaLoadBalancerRule() *schema.Resource {
 				Description: "The algorithm used to load balance",
 			},
 			"public_port": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "The port on the public IP",
 			},
 			"private_port": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "The port to which the traffic will be load balanced internally",
@@ -105,8 +105,8 @@ func createLbr(d *schema.ResourceData, meta interface{}) error {
 		NetworkId:   d.Get("network_id").(string),
 		Protocol:    d.Get("protocol").(string),
 		Algorithm:   d.Get("algorithm").(string),
-		PublicPort:  strconv.Itoa(d.Get("public_port").(int)),
-		PrivatePort: strconv.Itoa(d.Get("private_port").(int)),
+		PublicPort:  d.Get("public_port").(string),
+		PrivatePort: d.Get("private_port").(string),
 	}
 
 	_, instanceIdsPresent := d.GetOk("instance_ids")

--- a/cloudca/resource_cloudca_network_acl_rule.go
+++ b/cloudca/resource_cloudca_network_acl_rule.go
@@ -2,7 +2,6 @@ package cloudca
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/cloud-ca/go-cloudca"
@@ -36,7 +35,7 @@ func resourceCloudcaNetworkACLRule() *schema.Resource {
 				Description: "ID of environment where the network ACL rule should be created",
 			},
 			"rule_number": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The rule number of network ACL",
 			},
@@ -71,22 +70,22 @@ func resourceCloudcaNetworkACLRule() *schema.Resource {
 				},
 			},
 			"icmp_type": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The ICMP type. Can only be used with ICMP protocol.",
 			},
 			"icmp_code": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The ICMP code. Can only be used with ICMP protocol.",
 			},
 			"start_port": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The start port. Can only be used with TCP/UDP protocol.",
 			},
 			"end_port": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The end port. Can only be used with TCP/UDP protocol.",
 			},
@@ -107,7 +106,7 @@ func resourceCloudcaNetworkACLRuleCreate(d *schema.ResourceData, meta interface{
 		return rerr
 	}
 	aclRuleToCreate := cloudca.NetworkAclRule{
-		RuleNumber:   strconv.Itoa(d.Get("rule_number").(int)),
+		RuleNumber:   d.Get("rule_number").(string),
 		Cidr:         d.Get("cidr").(string),
 		Action:       d.Get("action").(string),
 		Protocol:     d.Get("protocol").(string),
@@ -139,7 +138,7 @@ func resourceCloudcaNetworkACLRuleUpdate(d *schema.ResourceData, meta interface{
 	}
 	aclRuleToUpdate := cloudca.NetworkAclRule{
 		Id:          d.Id(),
-		RuleNumber:  strconv.Itoa(d.Get("rule_number").(int)),
+		RuleNumber:  d.Get("rule_number").(string),
 		Cidr:        d.Get("cidr").(string),
 		Action:      d.Get("action").(string),
 		Protocol:    d.Get("protocol").(string),
@@ -182,19 +181,19 @@ func resourceCloudcaNetworkACLRuleRead(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error reading Trigger: %s", err)
 	}
 
-	if err := d.Set("icmp_type", readIntFromString(aclRule.IcmpType)); err != nil {
+	if err := d.Set("icmp_type", aclRule.IcmpType); err != nil {
 		return fmt.Errorf("Error reading Trigger: %s", err)
 	}
 
-	if err := d.Set("icmp_code", readIntFromString(aclRule.IcmpCode)); err != nil {
+	if err := d.Set("icmp_code", aclRule.IcmpCode); err != nil {
 		return fmt.Errorf("Error reading Trigger: %s", err)
 	}
 
-	if err := d.Set("start_port", readIntFromString(aclRule.StartPort)); err != nil {
+	if err := d.Set("start_port", aclRule.StartPort); err != nil {
 		return fmt.Errorf("Error reading Trigger: %s", err)
 	}
 
-	if err := d.Set("end_port", readIntFromString(aclRule.EndPort)); err != nil {
+	if err := d.Set("end_port", aclRule.EndPort); err != nil {
 		return fmt.Errorf("Error reading Trigger: %s", err)
 	}
 
@@ -219,18 +218,18 @@ func resourceCloudcaNetworkACLRuleDelete(d *schema.ResourceData, meta interface{
 
 func fillPortFields(d *schema.ResourceData, aclRule *cloudca.NetworkAclRule) {
 	if v, ok := d.GetOk("start_port"); ok {
-		aclRule.StartPort = strconv.Itoa(v.(int))
+		aclRule.StartPort = v.(string)
 	}
 	if v, ok := d.GetOk("end_port"); ok {
-		aclRule.EndPort = strconv.Itoa(v.(int))
+		aclRule.EndPort = v.(string)
 	}
 }
 
 func fillIcmpFields(d *schema.ResourceData, aclRule *cloudca.NetworkAclRule) {
 	if v, ok := d.GetOk("icmp_type"); ok {
-		aclRule.IcmpType = strconv.Itoa(v.(int))
+		aclRule.IcmpType = v.(string)
 	}
 	if v, ok := d.GetOk("icmp_code"); ok {
-		aclRule.IcmpCode = strconv.Itoa(v.(int))
+		aclRule.IcmpCode = v.(string)
 	}
 }

--- a/cloudca/resource_cloudca_port_forwarding_rule.go
+++ b/cloudca/resource_cloudca_port_forwarding_rule.go
@@ -2,7 +2,6 @@ package cloudca
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/cloud-ca/go-cloudca"
 	"github.com/cloud-ca/go-cloudca/services/cloudca"
@@ -45,26 +44,26 @@ func resourceCloudcaPortForwardingRule() *schema.Resource {
 				Description: "The protocol that this rule should use (eg. TCP, UDP)",
 			},
 			"private_port_start": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "The start of the private port range for this rule",
 			},
 			"private_port_end": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
 				Description: "The end of the private port range for this rule",
 			},
 			"public_port_start": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "The start of the public port range for this rule",
 			},
 			"public_port_end": {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
@@ -95,17 +94,17 @@ func createPortForwardingRule(d *schema.ResourceData, meta interface{}) error {
 	pfr := cloudca.PortForwardingRule{
 		PublicIpId:       d.Get("public_ip_id").(string),
 		Protocol:         d.Get("protocol").(string),
-		PublicPortStart:  strconv.Itoa(d.Get("public_port_start").(int)),
+		PublicPortStart:  d.Get("public_port_start").(string),
 		PrivateIpId:      d.Get("private_ip_id").(string),
-		PrivatePortStart: strconv.Itoa(d.Get("private_port_start").(int)),
+		PrivatePortStart: d.Get("private_port_start").(string),
 	}
 
 	if _, ok := d.GetOk("public_port_end"); ok {
-		pfr.PublicPortEnd = strconv.Itoa(d.Get("public_port_end").(int))
+		pfr.PublicPortEnd = d.Get("public_port_end").(string)
 	}
 
 	if _, ok := d.GetOk("private_port_end"); ok {
-		pfr.PrivatePortEnd = strconv.Itoa(d.Get("private_port_end").(int))
+		pfr.PrivatePortEnd = d.Get("private_port_end").(string)
 	}
 
 	newPfr, err := ccaResources.PortForwardingRules.Create(pfr)


### PR DESCRIPTION
Without this fix, we run into the following errors which completely breaks the ability for PFRs to function.  We are not able to `plan`, `apply` or `destroy` once the following error is hit.

```
* cloudca_port_forwarding_rule.master_tf_ui_pfr: Error reading Trigger: public_port_start: '' expected type 'int', got unconvertible type 'string'
```

To ensure that the fix was backwards compatible, I have tested to confirm that it works in both of the following scenarios (with ports defined as either `int` or `string` in terraform):
```
resource "cloudca_port_forwarding_rule" "master_tf_ui_pfr" {
  environment_id = "${cloudca_environment.tf_env.id}"
  public_ip_id = "${cloudca_public_ip.master_public_ip.id}"
  private_ip_id = "${cloudca_instance.master_instance.private_ip_id}"
  public_port_start = "8143"
  private_port_start = "8143"
  protocol = "TCP"
}

// and

resource "cloudca_port_forwarding_rule" "master_tf_ui_pfr" {
  environment_id = "${cloudca_environment.tf_env.id}"
  public_ip_id = "${cloudca_public_ip.master_public_ip.id}"
  private_ip_id = "${cloudca_instance.master_instance.private_ip_id}"
  public_port_start = 8143
  private_port_start = 8143
  protocol = "TCP"
}
```

**NOTE:**
I have fixed the same issue as described above for both the Load Balancing Rules and Network ACLs and included them in this patch.  Thanks @simongodard for pointing out that the same problem existed in these functions as well.  I have confirmed that the changes are backwards compatible, so we can pass `int` values in as we have in the past and they are handled correctly...