### PR TITLE
Replace makefile lint call in action to use recommended golangci-lint action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.12
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.12
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Verify 'vendor' dependencies
       run: make verify
@@ -28,23 +28,24 @@ jobs:
         export PATH=$PATH:$(go env GOPATH)/bin
         make goimports checkfmt
 
-    - name: Run linters
-      run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
-        make golangci lint
-
+    - name: Run golangci-lint
+      uses: golangci/golanci-lint-action@v2
+      with:
+        version: v1.29
+        # Optional: show only new issues if it's a pull request. default is false
+        # only-new-issues: true
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.12
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.12
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Run tests
       run: make test
@@ -54,13 +55,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.12
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.12
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Build binary for current OS/ARCH
       run: make build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
         make goimports checkfmt
 
     - name: Run golangci-lint
-      uses: golangci/golanci-lint-action@v2
+      uses: golangci/golangci-lint-action@v2
       with:
         version: v1.29
         # Optional: show only new issues if it's a pull request. default is false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,8 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.37.0
+        # Optional: if set to true then the action will use pre-installed Go.
+        skip-go-installation: true
         # Optional: show only new issues if it's a pull request. default is false
         # only-new-issues: true
   test:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.29
+        version: v1.37.0
         # Optional: show only new issues if it's a pull request. default is false
         # only-new-issues: true
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
   disable-all: true
   enable:
     - govet
-    - golint
+    - revive
     - goconst
     - misspell
     - varcheck

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ GOBUILD     := $(GOCMD) build $(MODVENDOR) -ldflags $(GOLDFLAGS)
 
 # Binary versions
 GITCHGLOG_VERSION := 0.8.0
-GOLANGCI_VERSION  := v1.18.0
+GOLANGCI_VERSION  := v1.43.0
 
 .PHONY: default
 default: help
@@ -86,7 +86,12 @@ checkfmt: ## Check formatting of go files
 .PHONY: test
 test: ## Run tests
 	@ $(MAKE) --no-print-directory log-$@
-	$(GOCMD) test $(MODVENDOR) -v $(GOPKGS)
+	TF_ACC= $(GOCMD) test $(MODVENDOR) -v $(GOPKGS)
+
+.PHONY: testacc
+testacc: ## Run acceptance tests
+	@ $(MAKE) --no-print-directory log-$@
+	TF_ACC=1 $(GOCMD) test $(MODVENDOR) -v $(GOPKGS)
 
 ###################
 ## Build targets ##
@@ -147,7 +152,7 @@ goimports:
 	GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
 
 golangci:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s  -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)bin $(GOLANGCI_VERSION)
 
 gox:
 	GO111MODULE=off go get -u github.com/mitchellh/gox

--- a/Makefile
+++ b/Makefile
@@ -86,12 +86,7 @@ checkfmt: ## Check formatting of go files
 .PHONY: test
 test: ## Run tests
 	@ $(MAKE) --no-print-directory log-$@
-	TF_ACC= $(GOCMD) test $(MODVENDOR) -v $(GOPKGS)
-
-.PHONY: testacc
-testacc: ## Run acceptance tests
-	@ $(MAKE) --no-print-directory log-$@
-	TF_ACC=1 $(GOCMD) test $(MODVENDOR) -v $(GOPKGS)
+	$(GOCMD) test $(MODVENDOR) -v $(GOPKGS)
 
 ###################
 ## Build targets ##


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [x] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

### Description
Upgrades dependencies in the makefile and github actions which were previously deprecated

### Issues Resolved
- updates the golangci Makefile command removing use of deprecated script `install.goreleaser.com` 
- replaces deprecated golint with revive as golint
- adds golangci-lint-action instead of running makefile action (recommended)
 
### Checklist

Put an `x` into all boxes that apply:

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
- [x] All checks pass when I run `make checkfmt` and `make lint`.
